### PR TITLE
Update dependency onpushstate@^0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Andrea Giammarchi",
   "license": "ISC",
   "dependencies": {
-    "onpushstate": "^0.1.1",
+    "onpushstate": "^0.3.1",
     "path-to-regexp": "^1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi :wave: 

I've noticed the fix for link clicks w/ modifiers is already included in `onpushstate@>=0.2.0` but `hyperhtml-app` is officially locked to `onpushstate@^0.1.1`.

I've [updated my app's lockfile to use `onpushstate@0.3.1`](https://github.com/soundsliceapp/prototype/commit/0bc7324e72b42851aa659ec153ce1b9b62a0aad7) and thought other `hyperhtml-app` users might want these fixes as well. :)

Includes fixes for:
- https://github.com/WebReflection/onpushstate/issues/2
- https://github.com/WebReflection/onpushstate/pull/1

Thanks a lot for all your work on the [viperHTML tech fam](https://viperhtml.js.org/) :ok_hand: 